### PR TITLE
Fix typo in admin.html

### DIFF
--- a/wsgiadmin/templates/admin.html
+++ b/wsgiadmin/templates/admin.html
@@ -97,7 +97,7 @@
                         <li>
                             <a href="{% url payments_info %}">
                                 <i class="icon-list-alt"></i>
-                                {% trans "Buyed credit" %}
+                                {% trans "Bought credit" %}
                             </a>
                         </li>
                         <li>


### PR DESCRIPTION
s/Buyed/Bought/

buyed is “nonstandard”: http://en.wiktionary.org/wiki/buyed
